### PR TITLE
Fixed merge an object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,8 +57,8 @@ var merge = exports.merge = function (obj1, obj2) {
   for (var p in obj2) {
     try {
       // Property in destination object set; update its value.
-      if ( obj2[p].constructor==Object ) {
-        obj1[p] = merge(obj1[p], obj2[p]);
+      if ( obj2[p].constructor==Object ) { 
+        obj1[p] = merge(obj1[p] || {}, obj2[p]);
       } else {
         obj1[p] = obj2[p];
       }


### PR DESCRIPTION
When we have some object in `obj2[p]` and an `obj1` is an empty object (see `/lib/form.js#L18` and `/lib/form.js#L23`), then an **undefined** will get into recursion as a first argument. So, we're trying to set property `p` into **undefined**: see `/lib/utils.js#L63`.
To prevent this, I've added checking if `obj1[p]` is NOT undefined or send an empty object into recursion `merge` call.